### PR TITLE
[agentic update repair] fix(packages): exclude t3code infra from desktop dependency source

### DIFF
--- a/packages/t3code/_shared.nix
+++ b/packages/t3code/_shared.nix
@@ -26,7 +26,6 @@ let
     path: builtins.attrNames (lib.filterAttrs (_: type: type == "directory") (builtins.readDir path));
   workspaceParentNames = [
     "apps"
-    "infra"
     "packages"
   ];
   workspaceParentDirs = builtins.filter (
@@ -67,7 +66,7 @@ let
   ++ lib.optional (builtins.pathExists (src + "/${mobileModuleRoot}")) mobileModuleRoot
   ++ mobileModulePackageDirs
   ++ lib.optional (builtins.pathExists (src + "/patches")) "patches";
-  dependencySource = builtins.path {
+  dependencySourceFiltered = builtins.path {
     name = "${pname}-dependency-source";
     path = src;
     filter =
@@ -88,6 +87,26 @@ let
         ++ map (dir: "${dir}/package.json") workspaceDirs
         ++ map (dir: "${dir}/package.json") mobileModulePackageDirs
       );
+  };
+  dependencySource = stdenv.mkDerivation {
+    name = "${pname}-dependency-source";
+    src = dependencySourceFiltered;
+
+    dontConfigure = true;
+    dontBuild = true;
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out"
+      cp -R . "$out/"
+      chmod -R u+w "$out"
+      substituteInPlace "$out/pnpm-workspace.yaml" \
+        --replace-fail "  - infra/*" ""
+
+      runHook postInstall
+    '';
   };
 
   node_modules =


### PR DESCRIPTION
## Repair

Restricts the T3 Code desktop dependency source to the workspaces used by `build:desktop` and normalizes `pnpm-workspace.yaml` so `infra/*` is not part of the frozen pnpm prefetch. The failed upstream lock entry is in `infra/relay`, which is unrelated to the packaged desktop build.

## Classifier

```json
{
  "decision": "auto_fix",
  "campaign_key": "update_flake_lock_action-28644233553",
  "run_id": "28644233553",
  "evidence": [
    "job 84949399990: ERR_PNPM_MISSING_TARBALL_INTEGRITY for alchemy@(pkg.ing/redacted) from infra/relay lockfile importer",
    "job 84949399948: [t3code-workspace] ERROR: Could not find hash in nix output after the package-specific pnpm dependency derivation failed",
    "upstream package.json build:desktop filters `@t3tools/desktop` and t3, so infra/* is unrelated to the packaged desktop build dependency closure"
  ],
  "reason": "T3 Code dependency prefetch failed on an unrelated infra workspace tarball entry; restrict the package dependency source to desktop build workspaces.",
  "failed_job_ids": [],
  "affected_paths": [
    "packages/t3code/_shared.nix"
  ]
}
```



## Reproduction

- Target run `28644233553` failed in jobs `84949399948` and `84949399990`.
- Logs show `ERR_PNPM_MISSING_TARBALL_INTEGRITY` for `alchemy@(pkg.ing/redacted) from the `infra/relay` lockfile importer, followed by `[t3code-workspace] ERROR: Could not find hash in nix output`.

## Validation

- `python3 lib/update/ci/self_heal.py parse-classifier /tmp/gh-aw/agent/classifier.json`
- `python3 lib/update/ci/self_heal.py render-classifier-marker --require-auto-fix /tmp/gh-aw/agent/classifier.json`
- `git diff --check`

`nix build .#packages.aarch64-darwin.t3code-workspace --no-link --print-build-logs` could not run in this repair runner because `nix` is not installed.

## Cycle count

Campaign `update_flake_lock_action-28644233553` has no prior ledger entries; this PR consumes automatic cycle 1 of 3.




> Generated by [Agentic Update Self-Heal](https://github.com/gkze/nixcfg/actions/runs/28653169758) · ● 17.1M · [◷](https://github.com/search?q=repo%3Agkze%2Fnixcfg+%22gh-aw-workflow-id%3A+update-self-heal%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Agentic Update Self-Heal, engine: copilot, version: 1.0.48, model: gpt-5.5, id: 28653169758, workflow_id: update-self-heal, run: https://github.com/gkze/nixcfg/actions/runs/28653169758 -->

<!-- gh-aw-workflow-id: update-self-heal -->