### PR TITLE
[agentic update repair] fix(packages): exclude t3code infra workspace from deps

### DIFF
--- a/packages/t3code/_shared.nix
+++ b/packages/t3code/_shared.nix
@@ -26,7 +26,6 @@ let
     path: builtins.attrNames (lib.filterAttrs (_: type: type == "directory") (builtins.readDir path));
   workspaceParentNames = [
     "apps"
-    "infra"
     "packages"
   ];
   workspaceParentDirs = builtins.filter (
@@ -67,8 +66,8 @@ let
   ++ lib.optional (builtins.pathExists (src + "/${mobileModuleRoot}")) mobileModuleRoot
   ++ mobileModulePackageDirs
   ++ lib.optional (builtins.pathExists (src + "/patches")) "patches";
-  dependencySource = builtins.path {
-    name = "${pname}-dependency-source";
+  dependencySourceBase = builtins.path {
+    name = "${pname}-dependency-source-base";
     path = src;
     filter =
       path: type:
@@ -88,6 +87,26 @@ let
         ++ map (dir: "${dir}/package.json") workspaceDirs
         ++ map (dir: "${dir}/package.json") mobileModulePackageDirs
       );
+  };
+  dependencySource = stdenv.mkDerivation {
+    pname = "${pname}-dependency-source";
+    version = nodeModulesVersion;
+    src = dependencySourceBase;
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out"
+      cp -R . "$out"
+      chmod u+w "$out/pnpm-workspace.yaml"
+      awk '$0 != "  - infra/*" { print }' "$out/pnpm-workspace.yaml" > "$out/pnpm-workspace.yaml.tmp"
+      mv "$out/pnpm-workspace.yaml.tmp" "$out/pnpm-workspace.yaml"
+
+      runHook postInstall
+    '';
   };
 
   node_modules =


### PR DESCRIPTION
## What changed

- Excludes upstream `infra/*` workspaces from the T3 Code dependency-cache source.
- Materializes a patched `pnpm-workspace.yaml` for the dependency probe so the desktop/server package lane does not install the malformed `alchemy` pkg.ing tarball from infra.

## Classifier

```json
{
  "decision": "auto_fix",
  "campaign_key": "update_flake_lock_action-28677399496",
  "run_id": "28677399496",
  "evidence": [
    "Failed Update run 28677399496 has only aarch64-darwin / t3code and aarch64-darwin / t3code-workspace failures.",
    "t3code-workspace failed with ERR_PNPM_MISSING_TARBALL_INTEGRITY for alchemy@(pkg.ing/redacted),
    "The failure is package-specific pnpm lockfile drift inside the t3code workspace dependency cache."
  ],
  "reason": "Package-specific t3code workspace pnpm lockfile integrity drift is eligible for a targeted package repair.",
  "failed_job_ids": [],
  "affected_paths": [
    "packages/t3code/_shared.nix"
  ]
}
```



## Reproduction

The failed Update run `28677399496` failed only `aarch64-darwin / t3code` and `aarch64-darwin / t3code-workspace`. Both logs point to `t3code-workspace-node_modules-pnpm-deps.drv`; the actionable error is `ERR_PNPM_MISSING_TARBALL_INTEGRITY` for `alchemy@(pkg.ing/redacted)

## Validation

- `python3 lib/update/ci/self_heal.py parse-classifier /tmp/gh-aw/agent/classifier.json`
- `python3 lib/update/ci/self_heal.py render-classifier-marker --require-auto-fix /tmp/gh-aw/agent/classifier.json`
- `python3 lib/update/ci/self_heal.py validate-auto-fix-paths --paths-file /tmp/gh-aw/agent/changed-paths.txt`
- `git diff --check`

`nix` and `uv` are not installed in this repair runner, so local package builds and pytest could not be executed here.

## Cycle count

Remaining automatic cycles before this repair: 3. This repair PR consumes 1 cycle.




> Generated by [Agentic Update Self-Heal](https://github.com/gkze/nixcfg/actions/runs/28683468977) · ● 14.3M · [◷](https://github.com/search?q=repo%3Agkze%2Fnixcfg+%22gh-aw-workflow-id%3A+update-self-heal%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Agentic Update Self-Heal, engine: copilot, version: 1.0.48, model: gpt-5.5, id: 28683468977, workflow_id: update-self-heal, run: https://github.com/gkze/nixcfg/actions/runs/28683468977 -->

<!-- gh-aw-workflow-id: update-self-heal -->