### PR TITLE
[agentic update repair] fix(packages): exclude t3code infra workspace from deps

### DIFF
--- a/lib/tests/test_packaging_source_modification_policy.py
+++ b/lib/tests/test_packaging_source_modification_policy.py
@@ -160,6 +160,11 @@ _ALLOWED_NIX_SUBSTITUTE_SITES: Final[tuple[NixSubstituteSite, ...]] = (
         "'CARGO_TARGET_${rustTargetEnv}_LINKER'",
     ),
     (
+        "packages/t3code/_shared.nix",
+        92,
+        'substituteInPlace pnpm-workspace.yaml --replace-fail "  - infra/*" ""',
+    ),
+    (
         "packages/superset/default.nix",
         278,
         'substituteInPlace package.json --replace-fail \'"postinstall": '

--- a/packages/t3code/_shared.nix
+++ b/packages/t3code/_shared.nix
@@ -26,7 +26,6 @@ let
     path: builtins.attrNames (lib.filterAttrs (_: type: type == "directory") (builtins.readDir path));
   workspaceParentNames = [
     "apps"
-    "infra"
     "packages"
   ];
   workspaceParentDirs = builtins.filter (
@@ -89,6 +88,10 @@ let
         ++ map (dir: "${dir}/package.json") mobileModulePackageDirs
       );
   };
+  pruneInfrastructureWorkspace = ''
+    substituteInPlace pnpm-workspace.yaml \
+      --replace-fail "  - infra/*" ""
+  '';
 
   node_modules =
     let
@@ -99,6 +102,7 @@ let
         inherit pnpm;
         fetcherVersion = 3;
         hash = outputs.lib.sourceHashForPlatform sourceHashPackageName "nodeModulesHash" system;
+        postPatch = pruneInfrastructureWorkspace;
       };
     in
     if fetchPnpmDeps != null then fetchPnpmDeps args else pnpm.fetchDeps args;
@@ -126,6 +130,8 @@ let
     postUnpack = ''
       chmod -R u+w source
     '';
+
+    postPatch = pruneInfrastructureWorkspace;
 
     buildPhase = ''
       runHook preBuild


### PR DESCRIPTION
## Classifier

```json
{
  "decision": "auto_fix",
  "campaign_key": "update_flake_lock_action-28698394328",
  "run_id": "28698394328",
  "evidence": [
    "job-85113092675.log: ERR_PNPM_MISSING_TARBALL_INTEGRITY for alchemy@(pkg.ing/redacted) Got no integrity checksum for this package in the lockfile, so it can't be verified",
    "job-85113092575.log: t3code update reaches the same t3code-workspace pnpm missing-tarball-integrity failure after refreshing package artifacts",
    "The pinned upstream pnpm-workspace.yaml includes infra/*, pulling infrastructure-only workspace dependencies into the packaged runtime dependency cache"
  ],
  "reason": "Deterministic package-specific T3 workspace dependency cache drift caused by an upstream infra workspace dependency with no lockfile integrity; repair is limited to packages/t3code and its focused policy baseline.",
  "failed_job_ids": [],
  "affected_paths": [
    "packages/t3code/_shared.nix",
    "lib/tests/test_packaging_source_modification_policy.py"
  ]
}
```



## Repair

Prunes the upstream `infra/*` workspace from the T3 Code dependency cache and build workspace. That keeps infrastructure-only pnpm dependencies, including the unverifiable `alchemy@pkg.ing` lockfile entry, out of the packaged runtime closure.

The focused packaging policy baseline is updated for the intentional `substituteInPlace` site.

## Reproduction

The failed Update run `28698394328` failed `t3code` and `t3code-workspace` jobs with `ERR_PNPM_MISSING_TARBALL_INTEGRITY` for `alchemy@(pkg.ing/redacted)

## Validation

- `python3 lib/update/ci/self_heal.py parse-classifier /tmp/gh-aw/agent/classifier.json`
- `python3 lib/update/ci/self_heal.py remaining-cycles --comments-json /tmp/gh-aw/agent/ledger-comments.json --campaign-key update_flake_lock_action-28698394328` returned `3`
- `python3 lib/update/ci/self_heal.py validate-auto-fix-paths --paths-file /tmp/gh-aw/agent/changed-paths.txt`
- `python3 lib/update/ci/self_heal.py render-classifier-marker --require-auto-fix /tmp/gh-aw/agent/classifier.json`
- `git diff --check`

Unable to run the usual Nix/uv validations in this runner because `nix` and `uv` are not installed, and system Python is 3.11 while this repo uses Python 3.14 syntax.

## Cycle count

Remaining cycles before this repair: 3.




> Generated by [Agentic Update Self-Heal](https://github.com/gkze/nixcfg/actions/runs/28702085165) · ● 18.3M · [◷](https://github.com/search?q=repo%3Agkze%2Fnixcfg+%22gh-aw-workflow-id%3A+update-self-heal%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Agentic Update Self-Heal, engine: copilot, version: 1.0.48, model: gpt-5.5, id: 28702085165, workflow_id: update-self-heal, run: https://github.com/gkze/nixcfg/actions/runs/28702085165 -->

<!-- gh-aw-workflow-id: update-self-heal -->