### PR TITLE
[agentic update repair] fix(packages): support bun-locked t3code workspace

### DIFF
--- a/packages/t3code-desktop/default.nix
+++ b/packages/t3code-desktop/default.nix
@@ -26,6 +26,7 @@ let
 
   shared = import ../t3code/_shared.nix {
     inherit
+      bun
       cacert
       fetchPnpmDeps
       inputs

--- a/packages/t3code-workspace/default.nix
+++ b/packages/t3code-workspace/default.nix
@@ -1,4 +1,5 @@
 {
+  bun,
   cacert,
   fetchPnpmDeps ? null,
   inputs,
@@ -12,6 +13,7 @@
 }:
 (import ../t3code/_shared.nix {
   inherit
+    bun
     cacert
     fetchPnpmDeps
     inputs

--- a/packages/t3code/_shared.nix
+++ b/packages/t3code/_shared.nix
@@ -1,4 +1,5 @@
 {
+  bun,
   cacert,
   fetchPnpmDeps ? null,
   inputs,
@@ -21,6 +22,7 @@ let
   revSuffix = builtins.substring 0 7 (outputs.lib.flakeLock.t3code.locked.rev or "unknown");
   version = "${baseVersion}-main-${revSuffix}";
   nodeModulesVersion = "deps";
+  hasBunLock = builtins.pathExists (src + "/bun.lock");
   pnpm = pnpm_10.override { inherit nodejs; };
   childDirectoryNames =
     path: builtins.attrNames (lib.filterAttrs (_: type: type == "directory") (builtins.readDir path));
@@ -82,6 +84,12 @@ let
       || builtins.elem relativePath (
         [
           "package.json"
+        ]
+        ++ lib.optionals hasBunLock [
+          "bun.lock"
+          "bunfig.toml"
+        ]
+        ++ lib.optionals (!hasBunLock) [
           "pnpm-lock.yaml"
           "pnpm-workspace.yaml"
         ]
@@ -90,7 +98,28 @@ let
       );
   };
 
-  node_modules =
+  bunTarget =
+    {
+      aarch64-darwin = {
+        cpu = "arm64";
+        os = "darwin";
+      };
+      x86_64-darwin = {
+        cpu = "x64";
+        os = "darwin";
+      };
+      aarch64-linux = {
+        cpu = "arm64";
+        os = "linux";
+      };
+      x86_64-linux = {
+        cpu = "x64";
+        os = "linux";
+      };
+    }
+    .${system} or (throw "Unsupported system ${system} for ${pname}");
+
+  pnpm_node_modules =
     let
       args = {
         pname = "${sourceHashPackageName}-node_modules";
@@ -103,14 +132,64 @@ let
     in
     if fetchPnpmDeps != null then fetchPnpmDeps args else pnpm.fetchDeps args;
 
-  workspaceBuild = stdenv.mkDerivation {
-    pname = "${pname}-workspace-build";
-    inherit version src;
-    pnpmDeps = node_modules;
+  bun_node_modules = stdenv.mkDerivation {
+    pname = "${sourceHashPackageName}-node_modules";
+    version = nodeModulesVersion;
+    src = dependencySource;
 
     nativeBuildInputs = [
+      bun
+      cacert
+    ];
+
+    dontPatchShebangs = true;
+    dontFixup = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export HOME="$TMPDIR/home"
+      mkdir -p "$HOME"
+      export SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt"
+      export NODE_EXTRA_CA_CERTS="$SSL_CERT_FILE"
+      export BUN_INSTALL_CACHE_DIR="$TMPDIR/.bun-cache"
+
+      bun install \
+        --cpu="${bunTarget.cpu}" \
+        --os="${bunTarget.os}" \
+        --frozen-lockfile \
+        --ignore-scripts \
+        --no-progress
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out"
+      find . -type d -name node_modules -prune -exec cp -R --parents {} "$out" \;
+
+      runHook postInstall
+    '';
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = outputs.lib.sourceHashForPlatform sourceHashPackageName "nodeModulesHash" system;
+  };
+
+  node_modules = if hasBunLock then bun_node_modules else pnpm_node_modules;
+
+  workspaceBuild = stdenv.mkDerivation ({
+    pname = "${pname}-workspace-build";
+    inherit version src;
+
+    nativeBuildInputs = [
+      bun
       cacert
       nodejs
+    ]
+    ++ lib.optionals (!hasBunLock) [
       pnpm
       pnpmConfigHook
     ];
@@ -142,8 +221,9 @@ let
       export XDG_STATE_HOME="$TMPDIR/xdg-state"
       export npm_config_manage_package_manager_versions=false
       mkdir -p "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME"
-      pnpm config set manage-package-manager-versions false
+      ${lib.optionalString (!hasBunLock) "pnpm config set manage-package-manager-versions false"}
 
+      ${lib.optionalString hasBunLock "cp -a ${node_modules}/. ."}
       chmod -R u+w node_modules ${workspaceBuildShellDirs}
 
       patchShebangs node_modules
@@ -151,7 +231,7 @@ let
         patchShebangs "$nested_node_modules"
       done
 
-      pnpm run build:desktop
+      ${if hasBunLock then "bun run build:desktop" else "pnpm run build:desktop"}
 
       runHook postBuild
     '';
@@ -167,10 +247,13 @@ let
 
       runHook postInstall
     '';
-  };
+  } // lib.optionalAttrs (!hasBunLock) {
+    pnpmDeps = node_modules;
+  });
 in
 {
   inherit
+    bunTarget
     node_modules
     pname
     pnpm

--- a/packages/t3code/default.nix
+++ b/packages/t3code/default.nix
@@ -17,6 +17,7 @@
 let
   shared = import ./_shared.nix {
     inherit
+      bun
       cacert
       fetchPnpmDeps
       inputs


### PR DESCRIPTION
Classifier decision: `auto_fix` for campaign `update_flake_lock_action-28732763933`.

```json
{
  "decision": "auto_fix",
  "campaign_key": "update_flake_lock_action-28732763933",
  "run_id": "28732763933",
  "evidence": [
    "job-85202336607.log: t3code-workspace failed while computing nodeModulesHash for the updated t3code input",
    "job-85202336495.log: ERR_PNPM_MISSING_TARBALL_INTEGRITY for alchemy@(pkg.ing/redacted) during pnpm dependency fetch",
    "Upstream pingdotgg/t3code revision 4f0f24f055fe5f5346f7e73372e8cdc167e052f9 switched the workspace dependency lock to root bun.lock with packageManager bun@1.3.11"
  ],
  "reason": "Package-specific T3 dependency cache drift: the updated upstream workspace now uses Bun lock data, while the derivation still forced pnpm dependency fetching for t3code-workspace.",
  "failed_job_ids": ["85202336495", "85202336607"],
  "affected_paths": [
    "packages/t3code/_shared.nix",
    "packages/t3code/default.nix",
    "packages/t3code-workspace/default.nix",
    "packages/t3code-desktop/default.nix"
  ]
}
```



Reproduction evidence:
- Failed run: `28732763933`.
- Failed jobs: `85202336495` (`aarch64-darwin / t3code`) and `85202336607` (`aarch64-darwin / t3code-workspace`).
- `job-85202336607.log` shows `t3code-workspace` failed while computing `nodeModulesHash` for the updated T3 input.
- `job-85202336495.log` shows pnpm dependency fetching failed with `ERR_PNPM_MISSING_TARBALL_INTEGRITY` for `alchemy@(pkg.ing/redacted)
- Upstream `pingdotgg/t3code` revision `4f0f24f055fe5f5346f7e73372e8cdc167e052f9` provides root `bun.lock` and `packageManager: bun@1.3.11`, while current `main` remains pnpm-locked.

Repair:
- Keep the existing pnpm dependency path for current T3 revisions without root `bun.lock`.
- Add a Bun fixed-output dependency path when the updated upstream source contains root `bun.lock`.
- Reuse the existing Bun CPU/OS target pattern across supported systems and wire `bun` through T3 package entrypoints.

Validation:
- `python3 lib/update/ci/self_heal.py parse-classifier /tmp/gh-aw/agent/classifier.json`
- `python3 lib/update/ci/self_heal.py validate-auto-fix-paths --paths-file /tmp/gh-aw/agent/repair-paths.txt`
- `python3 lib/update/ci/self_heal.py render-classifier-marker --require-auto-fix /tmp/gh-aw/agent/classifier.json`
- `git diff --check`

Local limitations:
- `nix` is unavailable in this runner, so the exact Nix derivation reproduction/build could not be run locally.
- `uv`, pytest, and ruff are unavailable in this runner; no Python files are changed in the final repair.

Cycle count: 3 automatic cycles remained before this repair attempt.




> Generated by [Agentic Update Self-Heal](https://github.com/gkze/nixcfg/actions/runs/28736517105) · ● 35.2M · [◷](https://github.com/search?q=repo%3Agkze%2Fnixcfg+%22gh-aw-workflow-id%3A+update-self-heal%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Agentic Update Self-Heal, engine: copilot, version: 1.0.48, model: gpt-5.5, id: 28736517105, workflow_id: update-self-heal, run: https://github.com/gkze/nixcfg/actions/runs/28736517105 -->

<!-- gh-aw-workflow-id: update-self-heal -->