### PR TITLE
[agentic update repair] fix(packages): exclude t3code infra workspace deps

### DIFF
--- a/packages/t3code/_shared.nix
+++ b/packages/t3code/_shared.nix
@@ -26,7 +26,6 @@ let
     path: builtins.attrNames (lib.filterAttrs (_: type: type == "directory") (builtins.readDir path));
   workspaceParentNames = [
     "apps"
-    "infra"
     "packages"
   ];
   workspaceParentDirs = builtins.filter (


### PR DESCRIPTION
Repair package-specific T3 Code workspace dependency drift from Update run `28740699843`.

The failed jobs were `aarch64-darwin / t3code` and `aarch64-darwin / t3code-workspace`. Both converge on the shared workspace dependency cache, which failed while installing upstream `infra/relay` dependencies because the upstream lockfile has no integrity metadata for `alchemy@(pkg.ing/redacted) The packaged desktop/server build does not use the upstream `infra/*` workspaces, so this repair excludes that parent from the dependency-cache source discovery and keeps the cache focused on `apps/*` and shared `packages/*` workspaces.

Classifier JSON:

```json
{
  "decision": "auto_fix",
  "campaign_key": "update_flake_lock_action-28740699843",
  "run_id": "28740699843",
  "evidence": [
    "Update run 28740699843 failed only package jobs aarch64-darwin / t3code and aarch64-darwin / t3code-workspace.",
    "Failed build /nix/store/7xk65shkbifb2jvpa44d2nqkw96rlrdy-t3code-workspace-node_modules-pnpm-deps.drv reports ERR_PNPM_MISSING_TARBALL_INTEGRITY for alchemy@(pkg.ing/redacted),
    "The failure is package-specific pnpm lockfile drift under packages/t3code-workspace, an allowed auto-fix lane."
  ],
  "reason": "t3code-workspace pnpm lock metadata drift; repair package-specific generated dependency artifacts.",
  "failed_job_ids": [],
  "affected_paths": [
    "packages/t3code/_shared.nix"
  ]
}
```



Reproduction:

```text
Failed build: t3code-workspace-node_modules-pnpm-deps.drv
ERR_PNPM_MISSING_TARBALL_INTEGRITY Cannot install package "alchemy@(pkg.ing/redacted) its lockfile entry has no "integrity" field.
```

Validation:

```text
python3 lib/update/ci/self_heal.py parse-classifier /tmp/gh-aw/agent/classifier.json
python3 lib/update/ci/self_heal.py render-classifier-marker --require-auto-fix /tmp/gh-aw/agent/classifier.json
```

Focused package build validation was not available in this self-heal runner because `nix` is not installed, and focused pytest was not available because the system Python lacks `pytest`.

Cycle count: 0 used before this repair; 3 remaining before this repair PR.




> Generated by [Agentic Update Self-Heal](https://github.com/gkze/nixcfg/actions/runs/28744736188) · ● 15.9M · [◷](https://github.com/search?q=repo%3Agkze%2Fnixcfg+%22gh-aw-workflow-id%3A+update-self-heal%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Agentic Update Self-Heal, engine: copilot, version: 1.0.48, model: gpt-5.5, id: 28744736188, workflow_id: update-self-heal, run: https://github.com/gkze/nixcfg/actions/runs/28744736188 -->

<!-- gh-aw-workflow-id: update-self-heal -->