### PR TITLE
[agentic update repair] fix(packages): exclude t3code infra workspace from pnpm scope

### DIFF
--- a/packages/t3code/_shared.nix
+++ b/packages/t3code/_shared.nix
@@ -24,9 +24,11 @@ let
   pnpm = pnpm_10.override { inherit nodejs; };
   childDirectoryNames =
     path: builtins.attrNames (lib.filterAttrs (_: type: type == "directory") (builtins.readDir path));
+  # The packaged desktop/server build does not use upstream infra workspaces.
+  # Keep them out of the pnpm install scope so unrelated infra-only tarballs do
+  # not break the package dependency cache.
   workspaceParentNames = [
     "apps"
-    "infra"
     "packages"
   ];
   workspaceParentDirs = builtins.filter (
@@ -67,7 +69,7 @@ let
   ++ lib.optional (builtins.pathExists (src + "/${mobileModuleRoot}")) mobileModuleRoot
   ++ mobileModulePackageDirs
   ++ lib.optional (builtins.pathExists (src + "/patches")) "patches";
-  dependencySource = builtins.path {
+  rawDependencySource = builtins.path {
     name = "${pname}-dependency-source";
     path = src;
     filter =
@@ -88,6 +90,26 @@ let
         ++ map (dir: "${dir}/package.json") workspaceDirs
         ++ map (dir: "${dir}/package.json") mobileModulePackageDirs
       );
+  };
+  dependencySource = stdenv.mkDerivation {
+    name = "${pname}-dependency-source";
+    src = rawDependencySource;
+
+    dontConfigure = true;
+    dontBuild = true;
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out"
+      cp -R . "$out"/
+      chmod -R u+w "$out"
+      substituteInPlace "$out/pnpm-workspace.yaml" \
+        --replace-fail "  - infra/*" ""
+
+      runHook postInstall
+    '';
   };
 
   node_modules =
@@ -125,6 +147,11 @@ let
 
     postUnpack = ''
       chmod -R u+w source
+    '';
+
+    postPatch = ''
+      substituteInPlace pnpm-workspace.yaml \
+        --replace-fail "  - infra/*" ""
     '';
 
     buildPhase = ''


### PR DESCRIPTION
## Classifier

```json
{
  "decision": "auto_fix",
  "campaign_key": "update_flake_lock_action-28750405867",
  "run_id": "28750405867",
  "evidence": [
    "Update run 28750405867 failed only the aarch64-darwin / t3code and aarch64-darwin / t3code-workspace jobs.",
    "Both failed logs end with ERR_PNPM_MISSING_TARBALL_INTEGRITY for alchemy@(pkg.ing/redacted),
    "The pinned T3 Code pnpm-lock.yaml has infra/relay depending on alchemy and its package entry has resolution.tarball but no resolution.integrity."
  ],
  "reason": "Package-specific T3 Code pnpm lock drift makes pnpm reject a tarball dependency while updating the package dependency cache.",
  "failed_job_ids": [],
  "affected_paths": [
    "packages/t3code/_shared.nix"
  ]
}
```



## Repair

Excludes upstream `infra/*` workspaces from the T3 Code package dependency source and build-time pnpm workspace scope. The packaged desktop/server build uses `apps/*`, `packages/*`, `oxlint-plugin-t3code`, and `scripts`; the failed `alchemy@(pkg.ing/redacted) tarball is only pulled by `infra/relay`.

## Reproduction

Target run `28750405867` failed only:

- `aarch64-darwin / t3code` (`85249373909`)
- `aarch64-darwin / t3code-workspace` (`85249374006`)

Both logs ended with `ERR_PNPM_MISSING_TARBALL_INTEGRITY` for `alchemy@(pkg.ing/redacted) The pinned upstream `pnpm-lock.yaml` entry has `resolution.tarball` without `resolution.integrity`.

## Validation

- `python3 lib/update/ci/self_heal.py parse-classifier /tmp/gh-aw/agent/classifier.json`
- `python3 lib/update/ci/self_heal.py validate-auto-fix-paths --paths-file /tmp/gh-aw/agent/changed-paths.txt`
- `python3 lib/update/ci/self_heal.py render-classifier-marker --require-auto-fix /tmp/gh-aw/agent/classifier.json`
- `git diff --check`

`nix` is not installed in this self-heal runner, so local Nix reproduction/build validation could not be executed here.

## Cycle count

Ledger remaining cycles before this repair: `3` of `3`.




> Generated by [Agentic Update Self-Heal](https://github.com/gkze/nixcfg/actions/runs/28754432926) · ● 13.9M · [◷](https://github.com/search?q=repo%3Agkze%2Fnixcfg+%22gh-aw-workflow-id%3A+update-self-heal%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Agentic Update Self-Heal, engine: copilot, version: 1.0.48, model: gpt-5.5, id: 28754432926, workflow_id: update-self-heal, run: https://github.com/gkze/nixcfg/actions/runs/28754432926 -->

<!-- gh-aw-workflow-id: update-self-heal -->