### PR TITLE
[agentic update repair] fix(packages): scope t3code pnpm dependency fetch

### DIFF
--- a/packages/t3code-desktop/sources.json
+++ b/packages/t3code-desktop/sources.json
@@ -2,7 +2,7 @@
   "drvHash": "ncn015qyh3ann2mb5p1pczpf0cn861ym",
   "hashes": [
     {
-      "hash": "sha256-o9i+Vi2ZaZqS4tmsq120o8qjgW4rtVSAxAHXC1exMLk=",
+      "hash": "sha256-O58w7FtBhHJKuTfvQAdZaSm4PWsyMI8neZqYG004XSA=",
       "hashType": "nodeModulesHash",
       "platform": "aarch64-darwin"
     }

--- a/packages/t3code/_shared.nix
+++ b/packages/t3code/_shared.nix
@@ -97,6 +97,10 @@ let
         version = nodeModulesVersion;
         src = dependencySource;
         inherit pnpm;
+        pnpmWorkspaces = [
+          "@t3tools/desktop"
+          "t3"
+        ];
         fetcherVersion = 3;
         hash = outputs.lib.sourceHashForPlatform sourceHashPackageName "nodeModulesHash" system;
       };

--- a/packages/t3code/sources.json
+++ b/packages/t3code/sources.json
@@ -2,7 +2,7 @@
   "drvHash": "194l1igakdyyj90vngfz38126j8jxqmw",
   "hashes": [
     {
-      "hash": "sha256-ryNJ+1AO0yrr+QvBg1wMprqelSxlficldtOgurOGNO4=",
+      "hash": "sha256-Y9AfiooBlQBIcBDuCavpLH45Czlzq9+n7hoJx6k3u2E=",
       "hashType": "nodeModulesHash",
       "platform": "aarch64-darwin"
     }


### PR DESCRIPTION
## Summary
- Scope the shared t3code `fetchPnpmDeps` call to the two workspaces actually built by `pnpm run build:desktop`: `@t3tools/desktop` and `t3`.
- Refresh the `t3code` and `t3code-desktop` runtime `nodeModulesHash` values emitted by failed Update run 28760200599 before the workspace fetch failed.

## Classifier
```json
{
  "decision": "auto_fix",
  "campaign_key": "update_flake_lock_action-28760200599",
  "run_id": "28760200599",
  "evidence": [
    "Failed Update run 28760200599 on main has failed jobs aarch64-darwin / t3code (85275360216) and aarch64-darwin / t3code-workspace (85275360304).",
    "t3code log: [t3code-workspace] ERROR: Could not find hash in nix output, then t3code and t3code-desktop hashes updated before failing the target job.",
    "t3code-workspace log: ERR_PNPM_MISSING_TARBALL_INTEGRITY for alchemy@(pkg.ing/redacted), a package-specific lock/install drift failure."
  ],
  "reason": "Failures are limited to t3code package runtime/PNPM lock drift under packages/** and are eligible for package-lane repair.",
  "failed_job_ids": [],
  "affected_paths": [
    "packages/t3code/sources.json",
    "packages/t3code/_shared.nix",
    "packages/t3code-desktop/sources.json",
    "packages/t3code-workspace/sources.json"
  ]
}
```



## Reproduction
- Inspected `/tmp/gh-aw/agent/evidence/logs/job-85275360216.log` and `/tmp/gh-aw/agent/evidence/logs/job-85275360304.log`.
- Confirmed `t3code-workspace` failed in `fetchPnpmDeps` with `ERR_PNPM_MISSING_TARBALL_INTEGRITY` for the unrelated upstream `infra/relay` dependency `alchemy@(pkg.ing/redacted)
- Checked nixpkgs `fetchPnpmDeps` support for `pnpmWorkspaces` filters and matched the filter to upstream root `build:desktop` (`@t3tools/desktop` and `t3`).

## Validation
- `python3 lib/update/ci/self_heal.py parse-classifier /tmp/gh-aw/agent/classifier.json`
- `python3 lib/update/ci/self_heal.py render-classifier-marker --require-auto-fix /tmp/gh-aw/agent/classifier.json`
- `git diff --check`

Nix-based reproduction was not available in this repair runner because `nix` is not installed; source-host cloning/Corepack fetches were also blocked, so the macOS/Nix repair workflow must compute or verify the filtered `t3code-workspace` dependency hash.

## Cycle count
Campaign `update_flake_lock_action-28760200599` has 3 automatic cycles remaining before this repair attempt.

## Worktree
Current branch: `agentic/update-self-heal/update_flake_lock_action-28760200599`
Final status before PR creation: `clean`




> Generated by [Agentic Update Self-Heal](https://github.com/gkze/nixcfg/actions/runs/28764780368) · ● 26.1M · [◷](https://github.com/search?q=repo%3Agkze%2Fnixcfg+%22gh-aw-workflow-id%3A+update-self-heal%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Agentic Update Self-Heal, engine: copilot, version: 1.0.48, model: gpt-5.5, id: 28764780368, workflow_id: update-self-heal, run: https://github.com/gkze/nixcfg/actions/runs/28764780368 -->

<!-- gh-aw-workflow-id: update-self-heal -->