### PR TITLE
chore(ci): disable workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,8 @@
 ---
 name: CI
 on:
-  workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      - main
+  # Disabled: keep the workflow valid without automatic or manual triggers.
+  workflow_call:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/update-certify.yml
+++ b/.github/workflows/update-certify.yml
@@ -6,12 +6,8 @@ env:
   UPDATE_BRANCH: update_flake_lock_action
 
 on:
-  workflow_run:
-    workflows:
-      - Update
-    types:
-      - completed
-  workflow_dispatch:
+  # Disabled: keep the workflow valid without automatic or manual triggers.
+  workflow_call:
     inputs:
       ref:
         description: Branch to certify. Defaults to the update branch from the refresh workflow.

--- a/.github/workflows/update-self-heal-pr.yml
+++ b/.github/workflows/update-self-heal-pr.yml
@@ -2,14 +2,8 @@
 name: Agentic Update Repair PR
 
 on:
-  pull_request:
-    branches:
-      - main
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - closed
+  # Disabled: keep the workflow valid without automatic or manual triggers.
+  workflow_call:
 
 permissions:
   actions: read

--- a/.github/workflows/update-self-heal.lock.yml
+++ b/.github/workflows/update-self-heal.lock.yml
@@ -53,7 +53,8 @@
 
 name: "Agentic Update Self-Heal"
 on:
-  workflow_dispatch:
+  # Disabled: keep the workflow valid without automatic or manual triggers.
+  workflow_call:
     inputs:
       aw_context:
         default: ""
@@ -68,17 +69,6 @@ on:
         description: Failed workflow run id to investigate.
         required: false
         type: string
-  workflow_run:
-    # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
-    branches:
-    - main
-    - agentic/update-self-heal/**
-    types:
-    - completed
-    workflows:
-    - Update
-    - "Update: Certify"
-    - CI
 
 permissions: {}
 

--- a/.github/workflows/update-self-heal.md
+++ b/.github/workflows/update-self-heal.md
@@ -2,17 +2,8 @@
 name: Agentic Update Self-Heal
 
 on:
-  workflow_run:
-    workflows:
-      - Update
-      - "Update: Certify"
-      - CI
-    types:
-      - completed
-    branches:
-      - main
-      - "agentic/update-self-heal/**"
-  workflow_dispatch:
+  # Disabled: keep the workflow valid without automatic or manual triggers.
+  workflow_call:
     inputs:
       run-id:
         description: Failed workflow run id to investigate.

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,9 +6,8 @@ env:
   UPDATE_COMMIT_MESSAGE: "chore: update flake.lock, sources, uv.lock, and crate2nix"
 
 on:
-  schedule:
-    - cron: "0 */6 * * *" # Every 6 hours
-  workflow_dispatch:
+  # Disabled: keep the workflow valid without automatic or manual triggers.
+  workflow_call:
 
 concurrency:
   group: flake-update-refresh


### PR DESCRIPTION
## Summary

- replace every workflow trigger block with `workflow_call` so workflows remain valid but do not run from pushes, PRs, schedules, workflow runs, or manual dispatch
- keep the generated agentic workflow lock file aligned with the source trigger shape without unrelated compiler churn
- restore GitHub Actions live repository permissions; this change is config-only

## Validation

- `nix run --inputs-from . nixpkgs#actionlint -- .github/workflows/ci.yml .github/workflows/update.yml .github/workflows/update-certify.yml .github/workflows/update-self-heal-pr.yml`
- `gh aw validate update-self-heal`
- `nix develop -c prek run -a`